### PR TITLE
Remove Conduit dependency version upper-bound

### DIFF
--- a/cereal-conduit.cabal
+++ b/cereal-conduit.cabal
@@ -14,7 +14,7 @@ homepage:        https://github.com/litherum/cereal-conduit
 
 library
     build-depends: base         >= 4       && < 5
-                 , conduit      >= 0.4.0   && < 0.5.0
+                 , conduit      >= 0.4.0
                  , cereal       >= 0.3.1.0
                  , bytestring
                  , void
@@ -26,7 +26,7 @@ Test-Suite test-cereal-conduit
     type: exitcode-stdio-1.0
     main-is: Test/Main.hs
     build-depends: base >= 4 && < 5
-                 , conduit >= 0.4.0 && < 0.5.0
+                 , conduit >= 0.4.0
                  , cereal >= 0.3.1.0
                  , bytestring
                  --, test-framework-hunit


### PR DESCRIPTION
I don't know the dependency versioning policies of this package, but: currently an upper bound of "conduit < 0.5" is defined, whilst the package seems to work fine with conduit-0.5.2.3. Could this be removed?
