### PR TITLE
Update for conduit 1.0

### DIFF
--- a/Data/Conduit/Cereal/Internal.hs
+++ b/Data/Conduit/Cereal/Internal.hs
@@ -10,7 +10,7 @@ module Data.Conduit.Cereal.Internal
   , mkSinkGet
   ) where
 
-import           Control.Monad (when)
+import           Control.Monad (forever, when)
 import qualified Data.ByteString as BS
 import qualified Data.Conduit as C
 import           Data.Serialize hiding (get, put)
@@ -38,7 +38,7 @@ mkConduitGet errorHandler get = consume True (runGetPartial get) [] BS.empty
           Partial p -> pull p consumed BS.empty
           Done a s' -> case initial of
                          -- this only works because the Get will either _always_ consume no input, or _never_ consume no input.
-                         True  -> sequence_ $ repeat $ C.yield a
+                         True  -> forever $ C.yield a
                          False -> C.yield a >> pull (runGetPartial get) [] s'
 --                         False -> C.yield a >> C.leftover s' >> mkConduitGet errorHandler get
           where consumed = s : b

--- a/Test/Main.hs
+++ b/Test/Main.hs
@@ -79,7 +79,7 @@ sinktest6 = TestCase (assertEqual "Leftover input works"
 -- Current sink implementation will terminate the pipe in case of error. 
 -- One may need non-terminating version like one defined below to get access to Leftovers
 
-sinkGetMaybe :: Get Word8 -> C.GLSink BS.ByteString (ExceptionT Identity) Word8
+sinkGetMaybe :: Get Word8 -> C.Consumer BS.ByteString (ExceptionT Identity) Word8
 sinkGetMaybe = mkSinkGet errorHandler terminationHandler
   where errorHandler       _ = return 34
         terminationHandler _ = return 114

--- a/cereal-conduit.cabal
+++ b/cereal-conduit.cabal
@@ -1,16 +1,21 @@
 name:            cereal-conduit
-version:         0.6
+version:         0.7
 license:         BSD3
 license-file:    LICENSE
 author:          Myles C. Maxfield <myles.maxfield@gmail.com>
 maintainer:      Myles C. Maxfield <myles.maxfield@gmail.com>
 synopsis:        Turn Data.Serialize Gets and Puts into Sources, Sinks, and Conduits
-description:     Turn Data.Serialize Gets and Puts into Sources, Sinks, and Conduits
+description:
+    Turn Data.Serialize Gets and Puts into Sources, Sinks, and Conduits.
+    .
+    [0.7]
+        Upgrade to conduit 1.0.0
 category:        Conduit
 stability:       Experimental
 cabal-version:   >= 1.8
 build-type:      Simple
 homepage:        https://github.com/litherum/cereal-conduit
+bug-reports:     https://github.com/litherum/cereal-conduit/issues
 
 library
     build-depends: base         >= 4       && < 5

--- a/cereal-conduit.cabal
+++ b/cereal-conduit.cabal
@@ -14,7 +14,7 @@ homepage:        https://github.com/litherum/cereal-conduit
 
 library
     build-depends: base         >= 4       && < 5
-                 , conduit      >= 0.5.0   && < 0.6.0
+                 , conduit      >= 1.0.0   && < 1.1
                  , cereal       >= 0.3.1.0
                  , bytestring
                  , transformers >= 0.2.0.0
@@ -25,15 +25,15 @@ library
 Test-Suite test-cereal-conduit
     type: exitcode-stdio-1.0
     main-is: Test/Main.hs
-    build-depends: base >= 4 && < 5
-                 , conduit >= 0.5.0 && < 0.6.0
-                 , cereal >= 0.3.1.0
+    build-depends: base
+                 , conduit
+                 , cereal
                  , bytestring
                  --, test-framework-hunit
                  , HUnit
                  , resourcet
                  , mtl
-                 , transformers >= 0.2.0.0
+                 , transformers
 
 source-repository head
   type:     git


### PR DESCRIPTION
This switches to conduit 1.0, dropping support for conduit 0.5 and bumping the major version number of this package.

I'm not a heavy conduit user (yet), so please look over these changes.
